### PR TITLE
Feature/#22 search delivery

### DIFF
--- a/common/src/main/java/com/sparta/common/util/PageableUtil.java
+++ b/common/src/main/java/com/sparta/common/util/PageableUtil.java
@@ -1,0 +1,19 @@
+package com.sparta.common.util;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public class PageableUtil {
+    public static Pageable makePageable(int page, int size, Sort.Order... orders) {
+        if (size != 10 && size != 30 && size != 50) {
+            size = 10;
+        }
+        Sort sort = Sort.by(orders);
+        return PageRequest.of(page, size, sort);
+    }
+
+    public static Sort.Order order(Sort.Direction direction, String field) {
+        return new Sort.Order(direction, field);
+    }
+}

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/application/dto/CreateDeliveryCommand.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/application/dto/CreateDeliveryCommand.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 public record CreateDeliveryCommand(
         UUID orderId,
+        Long userId,
         UUID departureHubId,
         UUID arrivalHubId,
         String deliveryAddress,

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/application/dto/CreateDeliveryResult.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/application/dto/CreateDeliveryResult.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 public record CreateDeliveryResult(
         UUID deliveryId,
         UUID orderId,
+        Long userId,
         DeliveryStatus status,
         UUID departureHubId,
         UUID arrivalHubId,
@@ -23,6 +24,7 @@ public record CreateDeliveryResult(
         return new CreateDeliveryResult(
                 delivery.getId(),
                 delivery.getOrderId(),
+                delivery.getUserId(),
                 delivery.getStatus(),
                 delivery.getDepartureHubId(),
                 delivery.getArrivalHubId(),

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/application/dto/SearchDeliveryDetailResult.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/application/dto/SearchDeliveryDetailResult.java
@@ -1,0 +1,37 @@
+package com.sparta.deliveryservice.application.dto;
+
+import com.sparta.deliveryservice.domain.model.Delivery;
+import com.sparta.deliveryservice.domain.model.DeliveryStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record SearchDeliveryDetailResult(
+        UUID deliveryId,
+        UUID orderId,
+        DeliveryStatus status,
+        UUID departureHubId,
+        UUID arrivalHubId,
+        String deliveryAddress,
+        String receiverName,
+        String receiverSlackId,
+        UUID companyAgentId,
+        LocalDateTime createdAt,
+        Long createdBy
+) {
+    public static SearchDeliveryDetailResult from(Delivery delivery) {
+        return new SearchDeliveryDetailResult(
+                delivery.getId(),
+                delivery.getOrderId(),
+                delivery.getStatus(),
+                delivery.getDepartureHubId(),
+                delivery.getArrivalHubId(),
+                delivery.getDeliveryAddress(),
+                delivery.getReceiverName(),
+                delivery.getReceiverSlackId(),
+                delivery.getCompanyAgentId(),
+                delivery.getCreatedAt(),
+                delivery.getCreatedBy()
+        );
+    }
+}

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/application/dto/SearchDeliveryDetailResult.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/application/dto/SearchDeliveryDetailResult.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 public record SearchDeliveryDetailResult(
         UUID deliveryId,
         UUID orderId,
+        Long userId,
         DeliveryStatus status,
         UUID departureHubId,
         UUID arrivalHubId,
@@ -23,6 +24,7 @@ public record SearchDeliveryDetailResult(
         return new SearchDeliveryDetailResult(
                 delivery.getId(),
                 delivery.getOrderId(),
+                delivery.getUserId(),
                 delivery.getStatus(),
                 delivery.getDepartureHubId(),
                 delivery.getArrivalHubId(),

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/application/dto/SearchDeliveryResult.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/application/dto/SearchDeliveryResult.java
@@ -1,0 +1,39 @@
+package com.sparta.deliveryservice.application.dto;
+
+import com.sparta.deliveryservice.domain.model.Delivery;
+import com.sparta.deliveryservice.domain.model.DeliveryStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record SearchDeliveryResult(
+        UUID deliveryId,
+        UUID orderId,
+        Long userId,
+        DeliveryStatus status,
+        UUID departureHubId,
+        UUID arrivalHubId,
+        String deliveryAddress,
+        String receiverName,
+        String receiverSlackId,
+        UUID companyAgentId,
+        LocalDateTime createdAt,
+        Long createdBy
+) {
+    public static SearchDeliveryResult from(Delivery delivery) {
+        return new SearchDeliveryResult(
+                delivery.getId(),
+                delivery.getOrderId(),
+                delivery.getUserId(),
+                delivery.getStatus(),
+                delivery.getDepartureHubId(),
+                delivery.getArrivalHubId(),
+                delivery.getDeliveryAddress(),
+                delivery.getReceiverName(),
+                delivery.getReceiverSlackId(),
+                delivery.getCompanyAgentId(),
+                delivery.getCreatedAt(),
+                delivery.getCreatedBy()
+        );
+    }
+}

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/application/service/DeliveryService.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/application/service/DeliveryService.java
@@ -6,7 +6,6 @@ import com.sparta.deliveryservice.application.dto.CreateDeliveryResult;
 import com.sparta.deliveryservice.application.dto.SearchDeliveryDetailResult;
 import com.sparta.deliveryservice.application.dto.SearchDeliveryResult;
 import com.sparta.deliveryservice.domain.model.Delivery;
-import com.sparta.deliveryservice.domain.model.DeliveryStatus;
 import com.sparta.deliveryservice.domain.repository.DeliveryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -26,10 +25,9 @@ public class DeliveryService {
 
     @Transactional
     public CreateDeliveryResult createDelivery(CreateDeliveryCommand createDeliveryCommand) {
-        deliveryRepository.findByOrderId(createDeliveryCommand.orderId()).
-                ifPresent(delivery -> {
-                    throw new IllegalArgumentException("이미 해당 주문에 대한 배송이 존재합니다.");
-                });
+        if (deliveryRepository.existsByOrderIdAndDeletedAtIsNull(createDeliveryCommand.orderId())) {
+            throw new IllegalArgumentException("이미 해당 주문에 대한 배송이 존재합니다.");
+        }
 
         Delivery delivery = Delivery.of(
                 createDeliveryCommand.orderId(),
@@ -39,8 +37,8 @@ public class DeliveryService {
                 createDeliveryCommand.deliveryAddress(),
                 createDeliveryCommand.receiverName(),
                 createDeliveryCommand.receiverSlackId(),
-                createDeliveryCommand.companyAgentId(),
-                DeliveryStatus.HUB_WAITING);
+                createDeliveryCommand.companyAgentId()
+        );
 
         delivery = deliveryRepository.save(delivery);
 
@@ -74,11 +72,11 @@ public class DeliveryService {
             }
 
             case "HUB_MANAGER" -> {
-                yield deliveryRepository.findAllByDepartureHubIdOrArrivalHubIdAndDeletedAtIsNull(tempHubId,tempHubId,pageable);
+                yield deliveryRepository.findAllByDepartureHubIdOrArrivalHubIdAndDeletedAtIsNull(tempHubId, tempHubId, pageable);
             }
 
-            case "DELIVERY_MANAGER","COMPANY_MANAGER" -> {
-                yield deliveryRepository.findAllByUserIdAndDeletedAtIsNull(tempUserId,pageable);
+            case "DELIVERY_MANAGER", "COMPANY_MANAGER" -> {
+                yield deliveryRepository.findAllByUserIdAndDeletedAtIsNull(tempUserId, pageable);
             }
             default -> throw new IllegalStateException("권한이 유효하지 않습니다.");
         };

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/application/service/DeliveryService.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/application/service/DeliveryService.java
@@ -2,12 +2,15 @@ package com.sparta.deliveryservice.application.service;
 
 import com.sparta.deliveryservice.application.dto.CreateDeliveryCommand;
 import com.sparta.deliveryservice.application.dto.CreateDeliveryResult;
+import com.sparta.deliveryservice.application.dto.SearchDeliveryDetailResult;
 import com.sparta.deliveryservice.domain.model.Delivery;
 import com.sparta.deliveryservice.domain.model.DeliveryStatus;
 import com.sparta.deliveryservice.domain.repository.DeliveryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -36,5 +39,12 @@ public class DeliveryService {
         delivery = deliveryRepository.save(delivery);
 
         return CreateDeliveryResult.from(delivery);
+    }
+
+    public SearchDeliveryDetailResult searchDeliveryDetail(UUID deliveryId) {
+        Delivery delivery = deliveryRepository.findById(deliveryId).orElseThrow(() ->
+                new IllegalArgumentException("배송을 찾을수 없습니다."));
+
+        return SearchDeliveryDetailResult.from(delivery);
     }
 }

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/application/service/DeliveryService.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/application/service/DeliveryService.java
@@ -1,12 +1,17 @@
 package com.sparta.deliveryservice.application.service;
 
+import com.sparta.common.util.PageableUtil;
 import com.sparta.deliveryservice.application.dto.CreateDeliveryCommand;
 import com.sparta.deliveryservice.application.dto.CreateDeliveryResult;
 import com.sparta.deliveryservice.application.dto.SearchDeliveryDetailResult;
+import com.sparta.deliveryservice.application.dto.SearchDeliveryResult;
 import com.sparta.deliveryservice.domain.model.Delivery;
 import com.sparta.deliveryservice.domain.model.DeliveryStatus;
 import com.sparta.deliveryservice.domain.repository.DeliveryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +33,7 @@ public class DeliveryService {
 
         Delivery delivery = Delivery.of(
                 createDeliveryCommand.orderId(),
+                createDeliveryCommand.userId(),
                 createDeliveryCommand.departureHubId(),
                 createDeliveryCommand.arrivalHubId(),
                 createDeliveryCommand.deliveryAddress(),
@@ -42,9 +48,41 @@ public class DeliveryService {
     }
 
     public SearchDeliveryDetailResult searchDeliveryDetail(UUID deliveryId) {
-        Delivery delivery = deliveryRepository.findById(deliveryId).orElseThrow(() ->
+        Delivery delivery = deliveryRepository.findByIdAndDeletedAtIsNull(deliveryId).orElseThrow(() ->
                 new IllegalArgumentException("배송을 찾을수 없습니다."));
 
         return SearchDeliveryDetailResult.from(delivery);
+    }
+
+    /**
+     * 배송 목록 조회 (권한별 자동 필터링)
+     * <p>
+     * TODO: User Service 연동 후 임시 파라미터 제거하고 SecurityUtils 사용
+     */
+    public Page<SearchDeliveryResult> searchDelivery(Long tempUserId, String tempRole, UUID tempHubId, int page, int size, Sort.Direction direction) {
+
+        Pageable pageable = PageableUtil.makePageable(page, size, PageableUtil.order(direction, "createdAt"));
+
+        // TODO: SecurityUtils로 대체
+        // Long currentUserId = SecurityUtils.getCurrentUserId();
+        // String currentUserRole = SecurityUtils.getCurrentUserRole();
+        // UUID currentUserHubId = SecurityUtils.getCurrentUserHubId();
+
+        Page<Delivery> deliveryPage = switch (tempRole) {
+            case "MASTER" -> {
+                yield deliveryRepository.findAllByDeletedAtIsNull(pageable);
+            }
+
+            case "HUB_MANAGER" -> {
+                yield deliveryRepository.findAllByDepartureHubIdOrArrivalHubIdAndDeletedAtIsNull(tempHubId,tempHubId,pageable);
+            }
+
+            case "DELIVERY_MANAGER","COMPANY_MANAGER" -> {
+                yield deliveryRepository.findAllByUserIdAndDeletedAtIsNull(tempUserId,pageable);
+            }
+            default -> throw new IllegalStateException("권한이 유효하지 않습니다.");
+        };
+
+        return deliveryPage.map(SearchDeliveryResult::from);
     }
 }

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/domain/model/Delivery.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/domain/model/Delivery.java
@@ -68,7 +68,7 @@ public class Delivery extends BaseEntity {
         this.receiverName = receiverName;
         this.receiverSlackId = receiverSlackId;
         this.companyAgentId = companyAgentId;
-        this.status = status;
+        this.status = DeliveryStatus.HUB_WAITING;
     }
 
     public static Delivery of(UUID orderId,
@@ -78,8 +78,7 @@ public class Delivery extends BaseEntity {
                               String deliveryAddress,
                               String receiverName,
                               String receiverSlackId,
-                              UUID companyAgentId,
-                              DeliveryStatus status) {
+                              UUID companyAgentId) {
         return Delivery.builder()
                 .orderId(orderId)
                 .userId(userId)
@@ -89,7 +88,6 @@ public class Delivery extends BaseEntity {
                 .receiverName(receiverName)
                 .receiverSlackId(receiverSlackId)
                 .companyAgentId(companyAgentId)
-                .status(status)
                 .build();
     }
 }

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/domain/model/Delivery.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/domain/model/Delivery.java
@@ -23,6 +23,9 @@ public class Delivery extends BaseEntity {
     private UUID orderId;
 
     @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
     private UUID departureHubId;
 
     @Column(nullable = false)
@@ -49,6 +52,7 @@ public class Delivery extends BaseEntity {
 
     @Builder(access = AccessLevel.PRIVATE)
     private Delivery(UUID orderId,
+                     Long userId,
                      UUID departureHubId,
                      UUID arrivalHubId,
                      String deliveryAddress,
@@ -57,6 +61,7 @@ public class Delivery extends BaseEntity {
                      UUID companyAgentId,
                      DeliveryStatus status) {
         this.orderId = orderId;
+        this.userId = userId;
         this.departureHubId = departureHubId;
         this.arrivalHubId = arrivalHubId;
         this.deliveryAddress = deliveryAddress;
@@ -67,6 +72,7 @@ public class Delivery extends BaseEntity {
     }
 
     public static Delivery of(UUID orderId,
+                              Long userId,
                               UUID departureHubId,
                               UUID arrivalHubId,
                               String deliveryAddress,
@@ -76,6 +82,7 @@ public class Delivery extends BaseEntity {
                               DeliveryStatus status) {
         return Delivery.builder()
                 .orderId(orderId)
+                .userId(userId)
                 .departureHubId(departureHubId)
                 .arrivalHubId(arrivalHubId)
                 .deliveryAddress(deliveryAddress)

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/domain/repository/DeliveryRepository.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/domain/repository/DeliveryRepository.java
@@ -1,13 +1,15 @@
 package com.sparta.deliveryservice.domain.repository;
 
+import com.sparta.deliveryservice.domain.model.Delivery;
+
 import java.util.Optional;
 import java.util.UUID;
-
-import com.sparta.deliveryservice.domain.model.Delivery;
 
 public interface DeliveryRepository {
 
 	Delivery save(Delivery delivery);
 
 	Optional<Delivery> findByOrderId(UUID orderId);
+
+	Optional<Delivery> findById(UUID deliveryId);
 }

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/domain/repository/DeliveryRepository.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/domain/repository/DeliveryRepository.java
@@ -1,6 +1,8 @@
 package com.sparta.deliveryservice.domain.repository;
 
 import com.sparta.deliveryservice.domain.model.Delivery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -11,5 +13,21 @@ public interface DeliveryRepository {
 
 	Optional<Delivery> findByOrderId(UUID orderId);
 
-	Optional<Delivery> findById(UUID deliveryId);
+	Optional<Delivery> findByIdAndDeletedAtIsNull(UUID deliveryId);
+
+	/**
+	 * MASTER - 전체 조회
+	 */
+	Page<Delivery> findAllByDeletedAtIsNull(Pageable pageable);
+
+	/**
+	 * 업체 담당자 - userId로 조회
+	 * 배송 담당자 - userId로 조회
+	 */
+	Page<Delivery> findAllByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable);
+
+	/**
+	 * 허브 담당자 - 출발 허브 OR 도착 허브로 조회
+	 */
+	Page<Delivery> findAllByDepartureHubIdOrArrivalHubIdAndDeletedAtIsNull(UUID departureHubId, UUID arrivalHubId, Pageable pageable);
 }

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/domain/repository/DeliveryRepository.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/domain/repository/DeliveryRepository.java
@@ -9,25 +9,25 @@ import java.util.UUID;
 
 public interface DeliveryRepository {
 
-	Delivery save(Delivery delivery);
+    Delivery save(Delivery delivery);
 
-	Optional<Delivery> findByOrderId(UUID orderId);
+    boolean existsByOrderIdAndDeletedAtIsNull(UUID orderId);
 
-	Optional<Delivery> findByIdAndDeletedAtIsNull(UUID deliveryId);
+    Optional<Delivery> findByIdAndDeletedAtIsNull(UUID deliveryId);
 
-	/**
-	 * MASTER - 전체 조회
-	 */
-	Page<Delivery> findAllByDeletedAtIsNull(Pageable pageable);
+    /**
+     * MASTER - 전체 조회
+     */
+    Page<Delivery> findAllByDeletedAtIsNull(Pageable pageable);
 
-	/**
-	 * 업체 담당자 - userId로 조회
-	 * 배송 담당자 - userId로 조회
-	 */
-	Page<Delivery> findAllByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable);
+    /**
+     * 업체 담당자 - userId로 조회
+     * 배송 담당자 - userId로 조회
+     */
+    Page<Delivery> findAllByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable);
 
-	/**
-	 * 허브 담당자 - 출발 허브 OR 도착 허브로 조회
-	 */
-	Page<Delivery> findAllByDepartureHubIdOrArrivalHubIdAndDeletedAtIsNull(UUID departureHubId, UUID arrivalHubId, Pageable pageable);
+    /**
+     * 허브 담당자 - 출발 허브 OR 도착 허브로 조회
+     */
+    Page<Delivery> findAllByDepartureHubIdOrArrivalHubIdAndDeletedAtIsNull(UUID departureHubId, UUID arrivalHubId, Pageable pageable);
 }

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/infrastructure/repository/DeliveryJpaRepository.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/infrastructure/repository/DeliveryJpaRepository.java
@@ -1,11 +1,31 @@
 package com.sparta.deliveryservice.infrastructure.repository;
 
 import com.sparta.deliveryservice.domain.model.Delivery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface DeliveryJpaRepository extends JpaRepository<Delivery, UUID> {
-	Optional<Delivery> findByOrderId(UUID orderId);
+    Optional<Delivery> findByOrderId(UUID orderId);
+
+    Optional<Delivery> findByIdAndDeletedAtIsNull(UUID deliveryId);
+
+    /**
+     * MASTER - 전체 조회
+     */
+    Page<Delivery> findAllByDeletedAtIsNull(Pageable pageable);
+
+    /**
+     * 업체 담당자 - userId로 조회
+     * 배송 담당자 - userId로 조회
+     */
+    Page<Delivery> findAllByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable);
+
+    /**
+     * 허브 담당자 - 출발 허브 OR 도착 허브로 조회
+     */
+    Page<Delivery> findAllByDepartureHubIdOrArrivalHubIdAndDeletedAtIsNull(UUID departureHubId, UUID arrivalHubId, Pageable pageable);
 }

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/infrastructure/repository/DeliveryJpaRepository.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/infrastructure/repository/DeliveryJpaRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface DeliveryJpaRepository extends JpaRepository<Delivery, UUID> {
-    Optional<Delivery> findByOrderId(UUID orderId);
+    boolean existsByOrderIdAndDeletedAtIsNull(UUID orderId);
 
     Optional<Delivery> findByIdAndDeletedAtIsNull(UUID deliveryId);
 

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/infrastructure/repository/DeliveryRepositoryImpl.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/infrastructure/repository/DeliveryRepositoryImpl.java
@@ -22,4 +22,9 @@ public class DeliveryRepositoryImpl implements DeliveryRepository {
 	public Optional<Delivery> findByOrderId(UUID orderId) {
 		return jpaRepository.findByOrderId(orderId);
 	}
+
+	@Override
+	public Optional<Delivery> findById(UUID deliveryId) {
+		return jpaRepository.findById(deliveryId);
+	}
 }

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/infrastructure/repository/DeliveryRepositoryImpl.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/infrastructure/repository/DeliveryRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.sparta.deliveryservice.infrastructure.repository;
 import com.sparta.deliveryservice.domain.model.Delivery;
 import com.sparta.deliveryservice.domain.repository.DeliveryRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -24,7 +26,22 @@ public class DeliveryRepositoryImpl implements DeliveryRepository {
 	}
 
 	@Override
-	public Optional<Delivery> findById(UUID deliveryId) {
-		return jpaRepository.findById(deliveryId);
+	public Optional<Delivery> findByIdAndDeletedAtIsNull(UUID deliveryId) {
+		return jpaRepository.findByIdAndDeletedAtIsNull(deliveryId);
+	}
+
+	@Override
+	public Page<Delivery> findAllByDeletedAtIsNull(Pageable pageable) {
+		return jpaRepository.findAllByDeletedAtIsNull(pageable);
+	}
+
+	@Override
+	public Page<Delivery> findAllByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable) {
+		return jpaRepository.findAllByUserIdAndDeletedAtIsNull(userId,pageable);
+	}
+
+	@Override
+	public Page<Delivery> findAllByDepartureHubIdOrArrivalHubIdAndDeletedAtIsNull(UUID departureHubId, UUID arrivalHubId, Pageable pageable) {
+		return jpaRepository.findAllByDepartureHubIdOrArrivalHubIdAndDeletedAtIsNull(departureHubId, arrivalHubId, pageable);
 	}
 }

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/infrastructure/repository/DeliveryRepositoryImpl.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/infrastructure/repository/DeliveryRepositoryImpl.java
@@ -13,35 +13,35 @@ import java.util.UUID;
 @Repository
 @RequiredArgsConstructor
 public class DeliveryRepositoryImpl implements DeliveryRepository {
-	private final DeliveryJpaRepository jpaRepository;
+    private final DeliveryJpaRepository jpaRepository;
 
-	@Override
-	public Delivery save(Delivery delivery) {
-		return jpaRepository.save(delivery);
-	}
+    @Override
+    public Delivery save(Delivery delivery) {
+        return jpaRepository.save(delivery);
+    }
 
-	@Override
-	public Optional<Delivery> findByOrderId(UUID orderId) {
-		return jpaRepository.findByOrderId(orderId);
-	}
+    @Override
+    public boolean existsByOrderIdAndDeletedAtIsNull(UUID orderId) {
+        return jpaRepository.existsByOrderIdAndDeletedAtIsNull(orderId);
+    }
 
-	@Override
-	public Optional<Delivery> findByIdAndDeletedAtIsNull(UUID deliveryId) {
-		return jpaRepository.findByIdAndDeletedAtIsNull(deliveryId);
-	}
+    @Override
+    public Optional<Delivery> findByIdAndDeletedAtIsNull(UUID deliveryId) {
+        return jpaRepository.findByIdAndDeletedAtIsNull(deliveryId);
+    }
 
-	@Override
-	public Page<Delivery> findAllByDeletedAtIsNull(Pageable pageable) {
-		return jpaRepository.findAllByDeletedAtIsNull(pageable);
-	}
+    @Override
+    public Page<Delivery> findAllByDeletedAtIsNull(Pageable pageable) {
+        return jpaRepository.findAllByDeletedAtIsNull(pageable);
+    }
 
-	@Override
-	public Page<Delivery> findAllByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable) {
-		return jpaRepository.findAllByUserIdAndDeletedAtIsNull(userId,pageable);
-	}
+    @Override
+    public Page<Delivery> findAllByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable) {
+        return jpaRepository.findAllByUserIdAndDeletedAtIsNull(userId, pageable);
+    }
 
-	@Override
-	public Page<Delivery> findAllByDepartureHubIdOrArrivalHubIdAndDeletedAtIsNull(UUID departureHubId, UUID arrivalHubId, Pageable pageable) {
-		return jpaRepository.findAllByDepartureHubIdOrArrivalHubIdAndDeletedAtIsNull(departureHubId, arrivalHubId, pageable);
-	}
+    @Override
+    public Page<Delivery> findAllByDepartureHubIdOrArrivalHubIdAndDeletedAtIsNull(UUID departureHubId, UUID arrivalHubId, Pageable pageable) {
+        return jpaRepository.findAllByDepartureHubIdOrArrivalHubIdAndDeletedAtIsNull(departureHubId, arrivalHubId, pageable);
+    }
 }

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/presentation/controller/DeliveryController.java
@@ -3,16 +3,17 @@ package com.sparta.deliveryservice.presentation.controller;
 import com.sparta.common.response.ApiResponse;
 import com.sparta.deliveryservice.application.dto.CreateDeliveryCommand;
 import com.sparta.deliveryservice.application.dto.CreateDeliveryResult;
+import com.sparta.deliveryservice.application.dto.SearchDeliveryDetailResult;
 import com.sparta.deliveryservice.application.service.DeliveryService;
 import com.sparta.deliveryservice.presentation.request.CreateDeliveryRequest;
 import com.sparta.deliveryservice.presentation.response.CreateDeliveryResponse;
+import com.sparta.deliveryservice.presentation.response.SearchDeliveryDetailResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/delivery")
@@ -33,5 +34,17 @@ public class DeliveryController {
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(response, "배송이 생성되었습니다."));
+    }
+
+    @GetMapping("/{deliveryId}")
+    public ResponseEntity<ApiResponse<SearchDeliveryDetailResponse>> searchDeliveryDetail(
+            @PathVariable UUID deliveryId
+            ){
+
+        SearchDeliveryDetailResult result = deliveryService.searchDeliveryDetail(deliveryId);
+
+        SearchDeliveryDetailResponse response = SearchDeliveryDetailResponse.from(result);
+
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response, "배송 상세 조회가 완료되었습니다."));
     }
 }

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/presentation/controller/DeliveryController.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/presentation/controller/DeliveryController.java
@@ -1,14 +1,19 @@
 package com.sparta.deliveryservice.presentation.controller;
 
 import com.sparta.common.response.ApiResponse;
+import com.sparta.common.response.PageResponse;
 import com.sparta.deliveryservice.application.dto.CreateDeliveryCommand;
 import com.sparta.deliveryservice.application.dto.CreateDeliveryResult;
 import com.sparta.deliveryservice.application.dto.SearchDeliveryDetailResult;
+import com.sparta.deliveryservice.application.dto.SearchDeliveryResult;
 import com.sparta.deliveryservice.application.service.DeliveryService;
 import com.sparta.deliveryservice.presentation.request.CreateDeliveryRequest;
 import com.sparta.deliveryservice.presentation.response.CreateDeliveryResponse;
 import com.sparta.deliveryservice.presentation.response.SearchDeliveryDetailResponse;
+import com.sparta.deliveryservice.presentation.response.SearchDeliveryResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -39,12 +44,30 @@ public class DeliveryController {
     @GetMapping("/{deliveryId}")
     public ResponseEntity<ApiResponse<SearchDeliveryDetailResponse>> searchDeliveryDetail(
             @PathVariable UUID deliveryId
-            ){
+    ) {
 
         SearchDeliveryDetailResult result = deliveryService.searchDeliveryDetail(deliveryId);
 
         SearchDeliveryDetailResponse response = SearchDeliveryDetailResponse.from(result);
 
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(response, "배송 상세 조회가 완료되었습니다."));
+    }
+
+    @GetMapping()
+    public ResponseEntity<ApiResponse<PageResponse<SearchDeliveryResponse>>> searchDelivery(
+            @RequestParam(required = false) Long tempUserId,        // 임시
+            @RequestParam(required = false) String tempRole,        // 임시
+            @RequestParam(required = false) UUID tempHubId,         // 임시
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "createdAt,desc") String sort
+    ) {
+        Sort.Direction direction = sort.equalsIgnoreCase("asc") ? Sort.Direction.ASC : Sort.Direction.DESC;
+
+        Page<SearchDeliveryResult> resultPage = deliveryService.searchDelivery(tempUserId, tempRole, tempHubId, page, size, direction);
+
+        Page<SearchDeliveryResponse> responsePage = resultPage.map(SearchDeliveryResponse::from);
+        PageResponse<SearchDeliveryResponse> pageResponse = PageResponse.of(responsePage);
+        return ResponseEntity.ok().body(ApiResponse.success(pageResponse,"배송 목록 조회가 완료되었습니다."));
     }
 }

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/presentation/request/CreateDeliveryRequest.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/presentation/request/CreateDeliveryRequest.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 public record CreateDeliveryRequest(
         UUID orderId,
+        Long userId,
         UUID departureHubId,
         UUID arrivalHubId,
         String deliveryAddress,
@@ -16,6 +17,7 @@ public record CreateDeliveryRequest(
     public CreateDeliveryCommand toCommand() {
         return new CreateDeliveryCommand(
                 this.orderId,
+                this.userId,
                 this.departureHubId,
                 this.arrivalHubId,
                 this.deliveryAddress,

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/presentation/response/CreateDeliveryResponse.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/presentation/response/CreateDeliveryResponse.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 public record CreateDeliveryResponse(
         UUID deliveryId,
         UUID orderId,
+        Long userId,
         DeliveryStatus status,
         UUID departureHubId,
         UUID arrivalHubId,
@@ -22,6 +23,7 @@ public record CreateDeliveryResponse(
         return CreateDeliveryResponse.builder()
                 .deliveryId(result.deliveryId())
                 .orderId(result.orderId())
+                .userId(result.userId())
                 .status(result.status())
                 .departureHubId(result.departureHubId())
                 .arrivalHubId(result.arrivalHubId())

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/presentation/response/SearchDeliveryDetailResponse.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/presentation/response/SearchDeliveryDetailResponse.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 public record SearchDeliveryDetailResponse(
         UUID deliveryId,
         UUID orderId,
+        Long userId,
         DeliveryStatus status,
         UUID departureHubId,
         UUID arrivalHubId,
@@ -24,6 +25,7 @@ public record SearchDeliveryDetailResponse(
         return new SearchDeliveryDetailResponse(
                 result.deliveryId(),
                 result.orderId(),
+                result.userId(),
                 result.status(),
                 result.departureHubId(),
                 result.arrivalHubId(),

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/presentation/response/SearchDeliveryDetailResponse.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/presentation/response/SearchDeliveryDetailResponse.java
@@ -1,0 +1,38 @@
+package com.sparta.deliveryservice.presentation.response;
+
+import com.sparta.deliveryservice.application.dto.SearchDeliveryDetailResult;
+import com.sparta.deliveryservice.domain.model.DeliveryStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record SearchDeliveryDetailResponse(
+        UUID deliveryId,
+        UUID orderId,
+        DeliveryStatus status,
+        UUID departureHubId,
+        UUID arrivalHubId,
+        String deliveryAddress,
+        String receiverName,
+        String receiverSlackId,
+        UUID companyAgentId,
+        LocalDateTime createdAt,
+        Long createdBy
+) {
+
+    public static SearchDeliveryDetailResponse from(SearchDeliveryDetailResult result) {
+        return new SearchDeliveryDetailResponse(
+                result.deliveryId(),
+                result.orderId(),
+                result.status(),
+                result.departureHubId(),
+                result.arrivalHubId(),
+                result.deliveryAddress(),
+                result.receiverName(),
+                result.receiverSlackId(),
+                result.companyAgentId(),
+                result.createdAt(),
+                result.createdBy()
+        );
+    }
+}

--- a/delivery-service/src/main/java/com/sparta/deliveryservice/presentation/response/SearchDeliveryResponse.java
+++ b/delivery-service/src/main/java/com/sparta/deliveryservice/presentation/response/SearchDeliveryResponse.java
@@ -1,0 +1,40 @@
+package com.sparta.deliveryservice.presentation.response;
+
+import com.sparta.deliveryservice.application.dto.SearchDeliveryResult;
+import com.sparta.deliveryservice.domain.model.DeliveryStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record SearchDeliveryResponse(
+        UUID deliveryId,
+        UUID orderId,
+        Long userId,
+        DeliveryStatus status,
+        UUID departureHubId,
+        UUID arrivalHubId,
+        String deliveryAddress,
+        String receiverName,
+        String receiverSlackId,
+        UUID companyAgentId,
+        LocalDateTime createdAt,
+        Long createdBy
+) {
+
+    public static SearchDeliveryResponse from(SearchDeliveryResult result){
+        return new SearchDeliveryResponse(
+                result.deliveryId(),
+                result.orderId(),
+                result.userId(),
+                result.status(),
+                result.departureHubId(),
+                result.arrivalHubId(),
+                result.deliveryAddress(),
+                result.receiverName(),
+                result.receiverSlackId(),
+                result.companyAgentId(),
+                result.createdAt(),
+                result.createdBy()
+        );
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩터링
- [ ] 환경 설정/빌드
- [x] 기타

## ❗️ 관련 이슈 링크
Close #22 

## 📝 개요
- 배송 목록 및 상세 조회 API 구현


## 🔁 변경 사항
- Common에 PagableUtil을 추가했습니다.
- Delivery 생성 시 초기 상태를 도메인 내부에서 설정하도록 개선했습니다.
- 중복 배송 검증 로직을 existsBy 변경했습니다.
- Delivery 엔티티에 userId 칼럼 추가했습니다.

## 👀 참고 사항
- 현재 구현된 목록 조회 Service 코드는 User 와 security가 구현되면 수정할 예정입니다.

## 👀 기타
<img width="927" height="671" alt="image" src="https://github.com/user-attachments/assets/9420698b-8c7b-4473-afef-6af09e55bd1b" />
