### PR TITLE
Feature/#27 허브간 이동 정보 생성

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -14,9 +14,9 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    api 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.17.2'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    api 'org.springframework.boot:spring-boot-starter-data-jpa'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     runtimeOnly 'org.postgresql:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/hub-service/build.gradle
+++ b/hub-service/build.gradle
@@ -15,9 +15,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
-    // common에서 못받아오는 것들
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // common
+    //implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    //implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 

--- a/hub-service/src/main/java/com/sparta/hubservice/application/dto/DijkstraRouteResult.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/application/dto/DijkstraRouteResult.java
@@ -1,0 +1,10 @@
+package com.sparta.hubservice.application.dto;
+
+import java.util.List;
+
+public record DijkstraRouteResult(
+        List<RouteSegmentDto> segments,
+        double totalDistance,
+        int totalTime
+) {
+}

--- a/hub-service/src/main/java/com/sparta/hubservice/application/dto/RouteSegmentDto.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/application/dto/RouteSegmentDto.java
@@ -1,0 +1,27 @@
+package com.sparta.hubservice.application.dto;
+
+import com.sparta.hubservice.domain.model.HubRoute;
+
+import java.util.UUID;
+
+// 각 구간 경로
+public record RouteSegmentDto(
+        UUID departureHubId,
+        String departureHubName,
+        UUID arrivalHubId,
+        String arrivalHubName,
+        double distance,
+        int timeInMinutes
+) {
+    // 엔티티를 dto로
+    public static RouteSegmentDto from(HubRoute segment){
+        return new RouteSegmentDto(
+                segment.getDepartureHub().getId(),
+                segment.getDepartureHub().getName(),
+                segment.getArrivalHub().getId(),
+                segment.getArrivalHub().getName(),
+                segment.getDistance(),
+                segment.getRequiredTime()
+        );
+    }
+}

--- a/hub-service/src/main/java/com/sparta/hubservice/application/service/DijkstraService.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/application/service/DijkstraService.java
@@ -1,0 +1,114 @@
+package com.sparta.hubservice.application.service;
+
+import com.sparta.hubservice.application.dto.DijkstraRouteResult;
+import com.sparta.hubservice.application.dto.RouteSegmentDto;
+import com.sparta.hubservice.domain.model.Hub;
+import com.sparta.hubservice.domain.model.HubRoute;
+import com.sparta.hubservice.domain.repository.HubRepository;
+import com.sparta.hubservice.domain.repository.HubRouteRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DijkstraService {
+
+    private final HubRepository hubRepository;
+    private final HubRouteRepository hubRouteRepository;
+
+    private record Node(Hub hub, int time) implements Comparable<Node> {
+        @Override
+        public int compareTo(Node other){
+            return Integer.compare(this.time, other.time);
+        }
+    }
+
+    // departure/arrival이 아닌 start/end : 경로 전체의 시작/끝 허브 말하므로 혼동하지 않기 위해
+    public DijkstraRouteResult findPath(UUID startHubId, UUID endHubId) {
+        List<HubRoute> allOpenSegments = hubRouteRepository.findAll();
+
+        Map<UUID, List<HubRoute>> graph = new HashMap<>();
+        for (HubRoute segment : allOpenSegments) {
+            graph.computeIfAbsent(segment.getDepartureHub().getId(), k -> new ArrayList<>())
+                    .add(segment);
+        }
+
+        PriorityQueue<Node> pq = new PriorityQueue<>();
+        Map<UUID, Integer> minTimes = new HashMap<>();
+        Map<UUID, HubRoute> bestPathSegments = new HashMap<>();
+
+        List<Hub> allHubs = hubRepository.findAll();
+        for (Hub hub : allHubs) {
+            minTimes.put(hub.getId(), Integer.MAX_VALUE);
+        }
+
+        Hub startHub = hubRepository.findById(startHubId)
+                .orElseThrow(() -> new EntityNotFoundException("출발 허브를 찾을 수 없습니다."));
+        minTimes.put(startHubId, 0);
+        pq.add(new Node(startHub, 0));
+
+        while (!pq.isEmpty()) {
+            Node currentNode = pq.poll();
+            UUID currentHubId = currentNode.hub().getId();
+            int currentTime = currentNode.time();
+
+            if (currentTime > minTimes.get(currentHubId)) continue;
+
+            if (graph.containsKey(currentHubId)) {
+                for (HubRoute segment : graph.get(currentHubId)) {
+                    Hub neighborHub = segment.getArrivalHub();
+                    int segmentTime = segment.getRequiredTime();
+                    int newTime = currentTime + segmentTime;
+
+                    if (newTime < minTimes.get(neighborHub.getId())) {
+                        minTimes.put(neighborHub.getId(), newTime);
+                        bestPathSegments.put(neighborHub.getId(), segment);
+                        pq.add(new Node(neighborHub, newTime));
+                    }
+                }
+            }
+        }
+
+        //역으로 (경로)
+        return reconstructPath(startHubId, endHubId, minTimes, bestPathSegments);
+    }
+
+    private DijkstraRouteResult reconstructPath(UUID startHubId, UUID endHubId,
+                                                Map<UUID, Integer> minTimes,
+                                                Map<UUID, HubRoute> bestPathSegments) {
+
+        List<RouteSegmentDto> segments = new ArrayList<>();
+        double totalDistance = 0.0;
+        int totalTime = minTimes.get(endHubId);
+
+        if (totalTime == Integer.MAX_VALUE) {
+            log.warn("경로를 찾을 수 없습니다. (출발: {}, 도착: {})", startHubId, endHubId);
+            return new DijkstraRouteResult(Collections.emptyList(), 0, -1);
+        }
+
+        UUID currentHubId = endHubId;
+
+        // 도착~출발 거슬러 올라감
+        while (bestPathSegments.containsKey(currentHubId)) {
+
+            HubRoute segment = bestPathSegments.get(currentHubId);
+
+            segments.add(RouteSegmentDto.from(segment));
+            totalDistance += segment.getDistance();
+
+            currentHubId = segment.getDepartureHub().getId(); // 이전 허브로 이동
+        }
+
+        Collections.reverse(segments);
+
+        return new DijkstraRouteResult(segments, totalDistance, totalTime);
+    }
+
+}

--- a/hub-service/src/main/java/com/sparta/hubservice/application/service/HubRouteService.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/application/service/HubRouteService.java
@@ -1,0 +1,118 @@
+package com.sparta.hubservice.application.service;
+
+import com.sparta.hubservice.domain.model.Hub;
+import com.sparta.hubservice.domain.model.HubRoute;
+import com.sparta.hubservice.domain.repository.HubRepository;
+import com.sparta.hubservice.domain.repository.HubRouteRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HubRouteService {
+
+    private final HubRepository hubRepository;
+    private final HubRouteRepository hubRouteRepository;
+
+    private static final List<String> CENTRAL_HUB_NAMES = Arrays.asList(
+            "경기 남부 센터", "대전광역시 센터", "대구광역시 센터"
+    );
+
+    @Transactional
+    public void createSegmentsForNewHub(Hub newHub) {
+        log.info("관할 중앙 허브 배정 시작");
+        // 관할 중앙 허브 찾고
+        // 중앙 허브와의 거리/시간 구하고
+        // 세그먼트 두개 생성
+
+        // 중앙 허브 조회
+        List<Hub> centralHubs = hubRepository.findAllByNameIn(CENTRAL_HUB_NAMES);
+
+        if (centralHubs.size() < 3) {
+            log.error("필수 중앙 허브 3개 DB 부재");
+            throw new IllegalStateException("중앙 허브 데이터 누락");
+        }
+
+        Hub assignedCentralHub = findClosetHub(newHub, centralHubs);
+
+        log.info("중앙 허브 배정 결과 ({})", assignedCentralHub.getName());
+
+        // 세그먼트 생성 (허브->중앙허브, 중앙허브->허브)
+        // Todo ai로 실제값 조회해오기 -> 일단은 하드코딩
+        double dummyDistance = 10.0;
+        int dummyTime = 10;
+
+        HubRoute segment1 = HubRoute.of(newHub, assignedCentralHub, dummyDistance, dummyTime);
+        HubRoute segment2 = HubRoute.of(assignedCentralHub, newHub, dummyDistance, dummyTime);
+
+        hubRouteRepository.saveAll(Arrays.asList(segment1, segment2));
+        log.info("세그먼트 생성 완료");
+    }
+
+//    //Todo
+//    /**
+//     * [신규] "파업/화재" 등으로 경로(세그먼트)를 닫습니다. (논리적 삭제)
+//     */
+//    @Transactional // 쓰기 작업
+//    public void closeRoute(UUID routeId, Long adminId) { // (adminId는 예시, 실제로는 @AuthenticationPrincipal)
+//        log.warn("경로(세그먼트) {}를 관리자({})가 닫습니다(논리삭제).", routeId, adminId);
+//
+//        HubRoute route = hubRouteRepository.findById(routeId)
+//                .orElseThrow(() -> new EntityNotFoundException("해당 경로(세그먼트)를 찾을 수 없습니다."));
+//
+//        route.markDeleted(adminId); // BaseEntity의 논리적 삭제 메서드 호출
+//    }
+//
+//    /**
+//     * [신규] "파업" 등이 끝나 닫힌 경로(세그먼트)를 다시 엽니다. (논리적 삭제 복구)
+//     */
+//    @Transactional // 쓰기 작업
+//    public void openRoute(UUID routeId) {
+//        log.info("경로(세그먼트) {}를 다시 엽니다(복구).", routeId);
+//
+//        // (주의: findById는 @Where로 논리삭제된 것을 못 찾습니다.
+//        //  -> JpaRepository에 @Query로 deleted_at IS NOT NULL인 것을 찾는 메서드가 별도 필요)
+//        // HubRoute route = hubRouteRepository.findByIdIncludingDeleted(routeId)...
+//
+//        // (임시 로직: 일단 findById로 가정)
+//        HubRoute route = hubRouteRepository.findById(routeId)
+//                .orElseThrow(() -> new EntityNotFoundException("해당 경로(세그먼트)를 찾을 수 없습니다."));
+//
+//        route.restoreDeletion(); // BaseEntity의 논리적 삭제 복구 메서드 호출
+//    }
+
+    private Hub findClosetHub(Hub newHub, List<Hub> candidates) {
+        Hub closestHub = null;
+        double minDistance = Double.MAX_VALUE;
+
+        for(Hub candidate : candidates) {
+            double distance = calculateDistance(newHub.getLatitude(), newHub.getLongitude(), candidate.getLatitude(), candidate.getLongitude());
+
+            if (distance < minDistance) {
+                minDistance = distance;
+                closestHub = candidate;
+            }
+        }
+        return closestHub;
+    }
+
+    private double calculateDistance(double lat1, double lon1, double lat2, double lon2){
+        final int R = 6371;
+        double latDistance = Math.toRadians(lat2 - lat1);
+        double lonDistance = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(lonDistance / 2) * Math.sin(lonDistance / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c; // km 단위
+    }
+}

--- a/hub-service/src/main/java/com/sparta/hubservice/application/service/HubService.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/application/service/HubService.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 public class HubService {
 
 	private final HubRepository hubRepository;
+	private final HubRouteService hubRouteService;
 
 	@Transactional
 	public CreateHubResult createHub(CreateHubCommand command) {
@@ -37,6 +38,9 @@ public class HubService {
 
 		Hub savedHub = hubRepository.save(newHub);
 		log.info("허브 생성 완료 - hub id: " + savedHub.getId());
+
+		// 새로 생긴 허브-중앙 허브 경로(segment) 생성
+		hubRouteService.createSegmentsForNewHub(savedHub);
 
 		return CreateHubResult.from(savedHub);
 	}

--- a/hub-service/src/main/java/com/sparta/hubservice/domain/repository/HubRepository.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/domain/repository/HubRepository.java
@@ -16,4 +16,6 @@ public interface HubRepository {
     List<Hub> findAll();
 
     Optional<Hub> findById(UUID hubId);
+
+    List<Hub> findAllByNameIn(List<String> names);
 }

--- a/hub-service/src/main/java/com/sparta/hubservice/domain/repository/HubRepository.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/domain/repository/HubRepository.java
@@ -4,6 +4,7 @@ import com.sparta.hubservice.domain.model.Hub;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,6 +12,8 @@ public interface HubRepository {
     Hub save(Hub hub);
 
     Page<Hub> findAll(Pageable pageable);
+
+    List<Hub> findAll();
 
     Optional<Hub> findById(UUID hubId);
 }

--- a/hub-service/src/main/java/com/sparta/hubservice/domain/repository/HubRouteRepository.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/domain/repository/HubRouteRepository.java
@@ -1,0 +1,24 @@
+package com.sparta.hubservice.domain.repository;
+
+import com.sparta.hubservice.domain.model.HubRoute;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface HubRouteRepository {
+
+    //ApplicationRunner에서 사용 - 대량 저장
+    void saveAll(List<HubRoute> hubRoutes);
+
+    //ApplicationRunner에서 사용 - 데이터 존재 여부
+    long count();
+
+    // HubRouteService - 단건 저장
+    HubRoute save(HubRoute hubRoute);
+
+    // 단건 조회
+    Optional<HubRoute> findById(UUID id);
+
+    // Todo 출발/도착지 별로 조회하기..
+}

--- a/hub-service/src/main/java/com/sparta/hubservice/domain/repository/HubRouteRepository.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/domain/repository/HubRouteRepository.java
@@ -20,5 +20,7 @@ public interface HubRouteRepository {
     // 단건 조회
     Optional<HubRoute> findById(UUID id);
 
+
+    List<HubRoute> findAll();
     // Todo 출발/도착지 별로 조회하기..
 }

--- a/hub-service/src/main/java/com/sparta/hubservice/infra/repository/JpaRepository/HubJpaRepository.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/infra/repository/JpaRepository/HubJpaRepository.java
@@ -3,7 +3,12 @@ package com.sparta.hubservice.infra.repository.JpaRepository;
 import com.sparta.hubservice.domain.model.Hub;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface HubJpaRepository extends JpaRepository<Hub, UUID> {
+
+    List<Hub> findAllByNameIn(List<String> names);
+
+    Boolean existsByIdAndDeletedAtIsNull(UUID hubId);
 }

--- a/hub-service/src/main/java/com/sparta/hubservice/infra/repository/JpaRepository/HubJpaRepository.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/infra/repository/JpaRepository/HubJpaRepository.java
@@ -3,7 +3,10 @@ package com.sparta.hubservice.infra.repository.JpaRepository;
 import com.sparta.hubservice.domain.model.Hub;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface HubJpaRepository extends JpaRepository<Hub, UUID> {
+
+    List<Hub> findAllByNameIn(List<String> names);
 }

--- a/hub-service/src/main/java/com/sparta/hubservice/infra/repository/JpaRepository/HubRouteJpaRepository.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/infra/repository/JpaRepository/HubRouteJpaRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.hubservice.infra.repository.JpaRepository;
+
+import com.sparta.hubservice.domain.model.HubRoute;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface HubRouteJpaRepository extends JpaRepository<HubRoute, UUID> {
+}

--- a/hub-service/src/main/java/com/sparta/hubservice/infra/repository/repositoryImpl/HubRepositoryImpl.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/infra/repository/repositoryImpl/HubRepositoryImpl.java
@@ -37,4 +37,9 @@ public class HubRepositoryImpl implements HubRepository {
     public List<Hub> findAll() {
         return jpaRepository.findAll();
     }
+
+    @Override
+    public List<Hub> findAllByNameIn(List<String> names) {
+        return jpaRepository.findAllByNameIn(names);
+    }
 }

--- a/hub-service/src/main/java/com/sparta/hubservice/infra/repository/repositoryImpl/HubRepositoryImpl.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/infra/repository/repositoryImpl/HubRepositoryImpl.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -30,5 +31,10 @@ public class HubRepositoryImpl implements HubRepository {
     @Override
     public Optional<Hub> findById(UUID hubId){
         return jpaRepository.findById(hubId);
+    }
+
+    @Override
+    public List<Hub> findAll() {
+        return jpaRepository.findAll();
     }
 }

--- a/hub-service/src/main/java/com/sparta/hubservice/infra/repository/repositoryImpl/HubRouteRepositoryImpl.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/infra/repository/repositoryImpl/HubRouteRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.sparta.hubservice.infra.repository.repositoryImpl;
+
+import com.sparta.hubservice.domain.model.HubRoute;
+import com.sparta.hubservice.domain.repository.HubRouteRepository;
+import com.sparta.hubservice.infra.repository.JpaRepository.HubRouteJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class HubRouteRepositoryImpl implements HubRouteRepository {
+
+    private final HubRouteJpaRepository jpaRepository;
+
+    @Override
+    public void saveAll(List<HubRoute> hubRoutes){
+        jpaRepository.saveAll(hubRoutes);
+    }
+
+    @Override
+    public long count() {
+        return jpaRepository.count();
+    }
+
+    @Override
+    public HubRoute save(HubRoute hubRoute){
+        return jpaRepository.save(hubRoute);
+    }
+
+    @Override
+    public Optional<HubRoute> findById(UUID id){
+        return jpaRepository.findById(id);
+    }
+}

--- a/hub-service/src/main/java/com/sparta/hubservice/infra/repository/repositoryImpl/HubRouteRepositoryImpl.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/infra/repository/repositoryImpl/HubRouteRepositoryImpl.java
@@ -35,4 +35,9 @@ public class HubRouteRepositoryImpl implements HubRouteRepository {
     public Optional<HubRoute> findById(UUID id){
         return jpaRepository.findById(id);
     }
+
+    @Override
+    public List<HubRoute> findAll() {
+        return jpaRepository.findAll();
+    }
 }

--- a/hub-service/src/main/java/com/sparta/hubservice/infra/setup/HubRouteInitializer.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/infra/setup/HubRouteInitializer.java
@@ -6,6 +6,7 @@ import com.sparta.hubservice.domain.model.HubRoute;
 import com.sparta.hubservice.domain.repository.HubRepository;
 import com.sparta.hubservice.domain.repository.HubRouteRepository;
 import com.sparta.hubservice.infra.repository.JpaRepository.HubRouteJpaRepository;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
@@ -26,90 +27,127 @@ public class HubRouteInitializer implements ApplicationRunner {
     private final HubRepository hubRepository;
     private final HubRouteRepository hubRouteRepository;
 
-    private static final Map<String, String> hubToCentral = new HashMap<>();
-    private static final Map<String, Map<String, RouteInfo>> segments = new HashMap<>();
+    private static final String GYEONGGI_NAME  = "경기 남부 센터";
+    private static final String DAEJEON_NAME = "대전광역시 센터";
+    private static final String DAEGU_NAME = "대구광역시 센터";
 
-    private static final String GYEONGGI  = "경기 남부 센터";
-    private static final String DAEJEON = "대전광역시 센터";
-    private static final String DAEGU = "대구광역시 센터";
+    // 중앙 허브 간 경로
+    private static final List<String[]> CENTRAL_SEGMENTS = List.of(
+            new String[]{GYEONGGI_NAME, DAEJEON_NAME},
+            new String[]{DAEJEON_NAME, DAEGU_NAME},
+            new String[]{GYEONGGI_NAME, DAEGU_NAME}
+    );
 
-    private static void addSegment(String dep, String arr, double dist, int time) {
-        // (양방향으로 segments 맵에 데이터 추가...)
-        segments.computeIfAbsent(dep, k -> new HashMap<>()).put(arr, new RouteInfo(dist, time));
-        segments.computeIfAbsent(arr, k -> new HashMap<>()).put(dep, new RouteInfo(dist, time));
-    }
-
-    private record RouteInfo(double distance, int timeInMinutes) {}
-
-    // 1. 클래스 로드 시 H&S 규칙과 (임시) 데이터를 미리 정의
-    static {
-        // H&S 소속 정의
-        hubToCentral.put("경기 북부 센터", GYEONGGI);
-        hubToCentral.put("서울특별시 센터", GYEONGGI);
-        hubToCentral.put("인천광역시 센터", GYEONGGI);
-        hubToCentral.put("강원특별자치도 센터", GYEONGGI);
-        hubToCentral.put(GYEONGGI, GYEONGGI);
-
-        hubToCentral.put("충청남도 센터", DAEJEON);
-        hubToCentral.put("충청북도 센터", DAEJEON);
-        hubToCentral.put("세종특별자치시 센터", DAEJEON);
-        hubToCentral.put("전북특별자치도 센터", DAEJEON);
-        hubToCentral.put("광주광역시 센터", DAEJEON);
-        hubToCentral.put("전라남도 센터", DAEJEON);
-        hubToCentral.put(DAEJEON, DAEJEON);
-
-        hubToCentral.put("경상북도 센터", DAEGU);
-        hubToCentral.put("경상남도 센터", DAEGU);
-        hubToCentral.put("부산광역시 센터", DAEGU);
-        hubToCentral.put("울산광역시 센터", DAEGU);
-        hubToCentral.put(DAEGU, DAEGU);
-
-        // H&S "지도 조각" (세그먼트) 데이터 (임시 값)
-        // (실제로는 Google/Gemini API로 이 구간들의 실제 값을 조회해서 채워야 함)
-        addSegment("서울특별시 센터", GYEONGGI, 30.0, 45);
-        addSegment("세종특별자치시 센터", DAEJEON, 20.0, 20);
-        addSegment("부산광역시 센터", DAEGU, 80.0, 70);
-        // ... (나머지 14개 로컬 허브 <-> 중앙 허브 구간도 모두 추가해야 함) ...
-        addSegment(GYEONGGI, DAEJEON, 120.0, 90);
-        addSegment(DAEJEON, DAEGU, 100.0, 80);
-        addSegment(GYEONGGI, DAEGU, 220.0, 160); // (우회로)
-    }
+    // 저장된 각 허브들의 관할 허브 정하기 -> 계산해서
+    // 정해진 각 허브들과의 세그먼트 저장하기(거리, 시간) - 각 2개 (허브->중앙허브/중앙허브->허브)
 
     @Override
     @Transactional
-    public void run(ApplicationArguments args) throws Exception {
+    public void run(ApplicationArguments args) throws Exception{
 
-        if(hubRouteRepository.count() > 0) {
-            log.info("H&S 세그먼트가 DB에 존자합니다. (초기화 건너뜀)");
+        if (hubRouteRepository.count() > 0) {
+            log.info("H&S 세그먼트가 이미 존재 (초기화 건너뜀)");
             return;
         }
 
         List<Hub> allHubs = hubRepository.findAll();
         Map<String, Hub> hubMap = new HashMap<>();
-        for (Hub hub : allHubs){
+        for(Hub hub : allHubs) {
             hubMap.put(hub.getName(), hub);
         }
 
-        log.info("H&S 세그먼트 DB 저장 시작");
+        List<Hub> centralHubs = List.of(
+                hubMap.get(GYEONGGI_NAME),
+                hubMap.get(DAEJEON_NAME),
+                hubMap.get(DAEGU_NAME)
+        );
+
+        log.info("세그먼트 계산 및 DB 저장 시작");
         List<HubRoute> routesToSave = new ArrayList<>();
 
-        for (Map.Entry<String, Map<String, RouteInfo>> depEntry : segments.entrySet()){
-            String depHubName = depEntry.getKey();
-            Hub depHub = hubMap.get(depHubName);
-            if (depHub == null) continue;
+        // 가까운 중앙 허브 배정
+        for (Hub spokeHub : allHubs) {
+            // 중앙 허브 패스
+            if(spokeHub.getName().equals(GYEONGGI_NAME) ||
+               spokeHub.getName().equals(DAEJEON_NAME) ||
+               spokeHub.getName().equals(DAEGU_NAME)){
+                continue;
+            }
 
-            for(Map.Entry<String, RouteInfo> arrEntry : depEntry.getValue().entrySet()){
-                String arrHubName = arrEntry.getKey();
-                RouteInfo info = arrEntry.getValue();
-                Hub arrHub = hubMap.get(arrHubName);
-                if (arrHub == null) continue;
+            Hub closestCentralHub = findClosestCentralHub(spokeHub, centralHubs);
 
-                HubRoute route = HubRoute.of(depHub, arrHub, info.distance(), info.timeInMinutes());
-                routesToSave.add(route);
+            if (closestCentralHub != null){
+                double distance= calculateDistance(
+                        spokeHub.getLatitude(), spokeHub.getLongitude(),
+                        closestCentralHub.getLatitude(), closestCentralHub.getLongitude()
+                );
+
+                // 트럭 속도를 70km/h로 계산
+                int timeInMinutes = (int) ((distance / 70.0) * 60);
+
+                routesToSave.add(HubRoute.of(spokeHub, closestCentralHub, distance, timeInMinutes));
+                routesToSave.add(HubRoute.of(closestCentralHub, spokeHub, distance, timeInMinutes));
+            }
+        }
+
+        // 중앙 허브끼리 계산
+        for (String[] pair : CENTRAL_SEGMENTS) {
+            Hub hubA = hubMap.get(pair[0]);
+            Hub hubB = hubMap.get(pair[1]);
+
+            if(hubA != null && hubB != null) {
+                double distance = calculateDistance(
+                        hubA.getLatitude(), hubA.getLongitude(),
+                        hubB.getLatitude(), hubB.getLongitude()
+                );
+                int timeInMinutes = (int) ((distance / 70.0) * 60);
+
+                routesToSave.add(HubRoute.of(hubA, hubB, distance, timeInMinutes));
+                routesToSave.add(HubRoute.of(hubB, hubA, distance, timeInMinutes));
             }
         }
 
         hubRouteRepository.saveAll(routesToSave);
-        log.info("H&S 세그먼트 저장 완료: ({})", routesToSave.size());
+        log.info("세그먼트 초기 저장 완료");
+    }
+
+    private Hub findClosestCentralHub(Hub spokeHub, List<Hub> centralHubs) {
+        Hub closestHub = null;
+        double minDistance = Double.MAX_VALUE;
+
+        for (Hub central : centralHubs) {
+            double distance = calculateDistance(
+                    spokeHub.getLatitude(), spokeHub.getLongitude(),
+                    central.getLatitude(), central.getLongitude()
+            );
+
+            if (distance < minDistance) {
+                minDistance = distance;
+                closestHub = central;
+            }
+        }
+
+        if(closestHub != null) {
+            log.info("중앙 허브 배정 {} -> {}",
+                    spokeHub.getName(), closestHub.getName());
+        }
+
+        return closestHub;
+    }
+
+    // 위도, 경도로 계산
+    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        final int R = 6371;
+
+        double latDistance = Math.toRadians(lat2 - lat1);
+        double lonDistance = Math.toRadians(lon2 - lon1);
+
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(lonDistance / 2) * Math.sin(lonDistance / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return R * c; // (최종 거리 km)
     }
 }

--- a/hub-service/src/main/java/com/sparta/hubservice/infra/setup/HubRouteInitializer.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/infra/setup/HubRouteInitializer.java
@@ -1,0 +1,115 @@
+package com.sparta.hubservice.infra.setup;
+
+
+import com.sparta.hubservice.domain.model.Hub;
+import com.sparta.hubservice.domain.model.HubRoute;
+import com.sparta.hubservice.domain.repository.HubRepository;
+import com.sparta.hubservice.domain.repository.HubRouteRepository;
+import com.sparta.hubservice.infra.repository.JpaRepository.HubRouteJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HubRouteInitializer implements ApplicationRunner {
+
+    private final HubRepository hubRepository;
+    private final HubRouteRepository hubRouteRepository;
+
+    private static final Map<String, String> hubToCentral = new HashMap<>();
+    private static final Map<String, Map<String, RouteInfo>> segments = new HashMap<>();
+
+    private static final String GYEONGGI  = "경기 남부 센터";
+    private static final String DAEJEON = "대전광역시 센터";
+    private static final String DAEGU = "대구광역시 센터";
+
+    private static void addSegment(String dep, String arr, double dist, int time) {
+        // (양방향으로 segments 맵에 데이터 추가...)
+        segments.computeIfAbsent(dep, k -> new HashMap<>()).put(arr, new RouteInfo(dist, time));
+        segments.computeIfAbsent(arr, k -> new HashMap<>()).put(dep, new RouteInfo(dist, time));
+    }
+
+    private record RouteInfo(double distance, int timeInMinutes) {}
+
+    // 1. 클래스 로드 시 H&S 규칙과 (임시) 데이터를 미리 정의
+    static {
+        // H&S 소속 정의
+        hubToCentral.put("경기 북부 센터", GYEONGGI);
+        hubToCentral.put("서울특별시 센터", GYEONGGI);
+        hubToCentral.put("인천광역시 센터", GYEONGGI);
+        hubToCentral.put("강원특별자치도 센터", GYEONGGI);
+        hubToCentral.put(GYEONGGI, GYEONGGI);
+
+        hubToCentral.put("충청남도 센터", DAEJEON);
+        hubToCentral.put("충청북도 센터", DAEJEON);
+        hubToCentral.put("세종특별자치시 센터", DAEJEON);
+        hubToCentral.put("전북특별자치도 센터", DAEJEON);
+        hubToCentral.put("광주광역시 센터", DAEJEON);
+        hubToCentral.put("전라남도 센터", DAEJEON);
+        hubToCentral.put(DAEJEON, DAEJEON);
+
+        hubToCentral.put("경상북도 센터", DAEGU);
+        hubToCentral.put("경상남도 센터", DAEGU);
+        hubToCentral.put("부산광역시 센터", DAEGU);
+        hubToCentral.put("울산광역시 센터", DAEGU);
+        hubToCentral.put(DAEGU, DAEGU);
+
+        // H&S "지도 조각" (세그먼트) 데이터 (임시 값)
+        // (실제로는 Google/Gemini API로 이 구간들의 실제 값을 조회해서 채워야 함)
+        addSegment("서울특별시 센터", GYEONGGI, 30.0, 45);
+        addSegment("세종특별자치시 센터", DAEJEON, 20.0, 20);
+        addSegment("부산광역시 센터", DAEGU, 80.0, 70);
+        // ... (나머지 14개 로컬 허브 <-> 중앙 허브 구간도 모두 추가해야 함) ...
+        addSegment(GYEONGGI, DAEJEON, 120.0, 90);
+        addSegment(DAEJEON, DAEGU, 100.0, 80);
+        addSegment(GYEONGGI, DAEGU, 220.0, 160); // (우회로)
+    }
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) throws Exception {
+
+        if(hubRouteRepository.count() > 0) {
+            log.info("H&S 세그먼트가 DB에 존자합니다. (초기화 건너뜀)");
+            return;
+        }
+
+        List<Hub> allHubs = hubRepository.findAll();
+        Map<String, Hub> hubMap = new HashMap<>();
+        for (Hub hub : allHubs){
+            hubMap.put(hub.getName(), hub);
+        }
+
+        log.info("H&S 세그먼트 DB 저장 시작");
+        List<HubRoute> routesToSave = new ArrayList<>();
+
+        for (Map.Entry<String, Map<String, RouteInfo>> depEntry : segments.entrySet()){
+            String depHubName = depEntry.getKey();
+            Hub depHub = hubMap.get(depHubName);
+            if (depHub == null) continue;
+
+            for(Map.Entry<String, RouteInfo> arrEntry : depEntry.getValue().entrySet()){
+                String arrHubName = arrEntry.getKey();
+                RouteInfo info = arrEntry.getValue();
+                Hub arrHub = hubMap.get(arrHubName);
+                if (arrHub == null) continue;
+
+                HubRoute route = HubRoute.of(depHub, arrHub, info.distance(), info.timeInMinutes());
+                routesToSave.add(route);
+            }
+        }
+
+        hubRouteRepository.saveAll(routesToSave);
+        log.info("H&S 세그먼트 저장 완료: ({})", routesToSave.size());
+    }
+}

--- a/hub-service/src/main/java/com/sparta/hubservice/infra/setup/HubRouteInitializer.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/infra/setup/HubRouteInitializer.java
@@ -5,8 +5,6 @@ import com.sparta.hubservice.domain.model.Hub;
 import com.sparta.hubservice.domain.model.HubRoute;
 import com.sparta.hubservice.domain.repository.HubRepository;
 import com.sparta.hubservice.domain.repository.HubRouteRepository;
-import com.sparta.hubservice.infra.repository.JpaRepository.HubRouteJpaRepository;
-import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;

--- a/hub-service/src/main/java/com/sparta/hubservice/presentation/controller/HubRouteController.java
+++ b/hub-service/src/main/java/com/sparta/hubservice/presentation/controller/HubRouteController.java
@@ -1,0 +1,31 @@
+package com.sparta.hubservice.presentation.controller;
+
+import com.sparta.common.response.ApiResponse;
+import com.sparta.hubservice.application.dto.DijkstraRouteResult;
+import com.sparta.hubservice.application.service.DijkstraService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/hub-routes")
+public class HubRouteController {
+
+    private final DijkstraService dijkstraService;
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<DijkstraRouteResult>> findPath(
+            @RequestParam UUID start,
+            @RequestParam UUID end
+    ){
+        DijkstraRouteResult result = dijkstraService.findPath(start, end);
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/hub-service/src/main/resources/application.yml
+++ b/hub-service/src/main/resources/application.yml
@@ -13,12 +13,16 @@ spring:
     username: ${POSTGRES_USER}
     password: ${POSTGRES_PASSWORD}
   jpa:
+    defer-datasource-initialization: true
     hibernate:
       ddl-auto: create
     properties:
       hibernate:
         default_schema: hub_schema
         format_sql: true
+  sql:
+    init:
+      mode: always
 
 eureka:
   client:

--- a/hub-service/src/main/resources/data.sql
+++ b/hub-service/src/main/resources/data.sql
@@ -1,0 +1,22 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE SCHEMA IF NOT EXISTS hub_schema;
+
+INSERT INTO hub_schema.p_hub (id, name, address, latitude, longitude, status, created_at, updated_at) VALUES
+(gen_random_uuid(), '서울특별시 센터', '서울특별시 송파구 송파대로 55', 37.514467, 127.106177, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '경기 북부 센터', '경기도 고양시 덕양구 권율대로 570', 37.6901, 126.8715, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '경기 남부 센터', '경기도 이천시 덕평로 257-21', 37.2345, 127.3888, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '부산광역시 센터', '부산 동구 중앙대로 206', 35.11499, 129.04208, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '대구광역시 센터', '대구 북구 태평로 161', 35.87138, 128.60138, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '인천광역시 센터', '인천 남동구 정각로 29', 37.456133, 126.7062117, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '광주광역시 센터', '광주 서구 내방로 111', 35.1600, 126.8514, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '대전광역시 센터', '대전 서구 둔산로 100', 36.35, 127.385, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '울산광역시 센터', '울산 남구 중앙로 201', 35.53833, 129.31138, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '세종특별자치시 센터', '세종특별자치시 한누리대로 2130', 36.480058, 127.289039, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '강원특별자치도 센터', '강원특별자치도 춘천시 중앙로 1', 37.880072, 127.727908, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '전라남도 센터', '전남 무안군 삼향읍 오룡길 1', 35.027, 126.822, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '충청북도 센터', '충북 청주시 상당구 상당로 82', 36.6358, 127.4913, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '충청남도 센터', '충남 홍성군 홍북읍 충남대로 21', 36.6586, 126.6738, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '전북특별자치도 센터', '전북특별자치도 전주시 완산구 효자로 225', 35.8207, 127.1087, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '경상북도 센터', '경북 안동시 풍천면 도청대로 455', 36.5721, 128.5056, 'OPEN', NOW(), NOW()),
+(gen_random_uuid(), '경상남도 센터', '경남 창원시 의창구 중앙대로 300', 35.2380, 128.6923, 'OPEN', NOW(), NOW());


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩터링
- [ ] 환경 설정/빌드
- [ ] 기타

## ❗️ 관련 이슈 링크
Close #27 

## 📝 개요
- 허브간 이동 정보를 생성 및 반환하는 코드 구현

## 🔁 변경 사항
- 실행시 허브 17개를 저장
- 서버 실행시 저장되어있는 허브 바탕으로 허브 경로 segment 생성
- 새 허브 생성시 해당 허브 관리 중앙 허브 할당 및 segment 2개 생성
- 출발&도착 허브에 따른 이동 정보 제공(전체 소요시간, 거리, 전체 경로 출발/도착 허브, 각 경로간의 출발/도착 허브, 소요시간, 거리)

## 👀 참고 사항
- 다른 팀원에게 알릴 내용이 있으면 작성해주세요.

## 👀 기타
<img width="1444" height="1422" alt="image" src="https://github.com/user-attachments/assets/9e98b895-beb1-47fe-b791-260e7c9a2dfa" />
경로 탐색을 할 시 
<img width="524" height="425" alt="image" src="https://github.com/user-attachments/assets/7350d074-04b0-4432-a3e5-40dd5793bb2d" />
허브 생성을 하면
<img width="706" height="246" alt="image" src="https://github.com/user-attachments/assets/65239efb-0cf9-4b2a-a444-d5da708fffb3" />
<img width="706" height="246" alt="image" src="https://github.com/user-attachments/assets/9c89374a-e22d-48ef-859d-7bfc46bff10c" />
